### PR TITLE
Lint the Brewfile in developer-onboarding

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
-tap "go-task/tap"
-cask "docker"
-brew "go-task/tap/go-task"
+# frozen_string_literal: true
+
+tap 'go-task/tap'
+cask 'docker'
+brew 'go-task/tap/go-task'


### PR DESCRIPTION
causing rubocop corrections in other repos that pull in this repo as a submodule.