### PR TITLE
Add docker entrypoint for Rubocop

### DIFF
--- a/docker/rails/docker-compose.yml
+++ b/docker/rails/docker-compose.yml
@@ -9,7 +9,6 @@ x-base-app-config: &base-app-config
     - ~/.gitconfig:/root/.gitconfig:ro
   environment:
     - WAIT_HOSTS=db:5432, cache:6379
-    - COMPOSE_PROJECT_NAME=rails
   env_file:
     - .env
     - .env-local

--- a/docker/rails/docker-compose.yml
+++ b/docker/rails/docker-compose.yml
@@ -9,6 +9,7 @@ x-base-app-config: &base-app-config
     - ~/.gitconfig:/root/.gitconfig:ro
   environment:
     - WAIT_HOSTS=db:5432, cache:6379
+    - COMPOSE_PROJECT_NAME=rails
   env_file:
     - .env
     - .env-local

--- a/docker/rails/docker-entrypoint.sh
+++ b/docker/rails/docker-entrypoint.sh
@@ -28,6 +28,10 @@ if [ "$1" = 'test' ]; then
   exec rspec "$@"
 fi
 
+if [ "$1" = 'lint' ]; then
+  exec app bundle exec rubocop -a
+fi
+
 if [ "$1" = 'bump-models' ]; then
   # Since the container filesystem may be out-of-date (see: http://docs.docker.oeynet.com/docker-for-mac/osxfs-caching/#cached), 
   # force an update of the git index.


### PR DESCRIPTION
1. Add the lint command to run Rubocop
2. One process I find myself having to repeat is: open the Fli-Rails directory, run the docker-compose file there, run my Fli-rails tests, realize I should make a set-core change down the line, open the Set-core directory, **tear down the existing Fli-rails containers**, **restart the Set-core containers**, and then run the Set-core tests/bump-models.

Running tests/bumping models are actually container app agnostic, so we can use for instance the Fli-rails app container to run set-core unit tests. We're primarily just interested in a standardized Ruby runtime for us to perform our actions.